### PR TITLE
Correct filter params

### DIFF
--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -120,7 +120,8 @@ paths:
           in: query
           description: Status values that need to be considered for filter
           required: false
-          explode: true
+          style: form
+          explode: false
           schema:
             type: string
             enum:
@@ -162,7 +163,8 @@ paths:
           in: query
           description: Tags to filter by
           required: false
-          explode: true
+          style: form
+          explode: false
           schema:
             type: array
             items:


### PR DESCRIPTION
The description on the findPetBy paths says
> Multiple status values can be provided with comma separated strings

But if we want that to be true, `explode` should be `false`.  
Otherwise we should expect repeated query parameters with the same key. Which is actually the API style that I prefer, FWIW.