### PR TITLE
Use readOnly and writeOnly on models

### DIFF
--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -616,6 +616,7 @@ components:
           type: integer
           format: int64
           example: 10
+          readOnly: true
         petId:
           type: integer
           format: int64
@@ -696,6 +697,7 @@ components:
           type: integer
           format: int64
           example: 10
+          readOnly: true
         username:
           type: string
           example: theUser
@@ -711,6 +713,7 @@ components:
         password:
           type: string
           example: 12345
+          writeOnly: true
         phone:
           type: string
           example: 12345
@@ -743,6 +746,7 @@ components:
           type: integer
           format: int64
           example: 10
+          readOnly: true
         name:
           type: string
           example: doggie


### PR DESCRIPTION
Clients presumably shouldn't be sending `id` fields in requests and definitely shouldn't be getting `password` fields back in responses.

The alternative to `readOnly` or `writeOnly` is to have one model for the request and one for the response for each data type.