### PR TITLE
Spec path parameters at path level

### DIFF
--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -188,20 +188,20 @@ paths:
             - 'write:pets'
             - 'read:pets'
   '/pet/{petId}':
+    parameters:
+      - name: petId
+        in: path
+        description: ID of pet
+        required: true
+        schema:
+          type: integer
+          format: int64
     get:
       tags:
         - pet
       summary: Find pet by ID
       description: Returns a single pet
       operationId: getPetById
-      parameters:
-        - name: petId
-          in: path
-          description: ID of pet to return
-          required: true
-          schema:
-            type: integer
-            format: int64
       responses:
         '200':
           description: successful operation
@@ -228,13 +228,6 @@ paths:
       description: ''
       operationId: updatePetWithForm
       parameters:
-        - name: petId
-          in: path
-          description: ID of pet that needs to be updated
-          required: true
-          schema:
-            type: integer
-            format: int64
         - name: name
           in: query
           description: Name of pet that needs to be updated
@@ -265,13 +258,6 @@ paths:
           required: false
           schema:
             type: string
-        - name: petId
-          in: path
-          description: Pet id to delete
-          required: true
-          schema:
-            type: integer
-            format: int64
       responses:
         '400':
           description: Invalid pet value
@@ -366,6 +352,14 @@ paths:
             schema:
               $ref: '#/components/schemas/Order'
   '/store/order/{orderId}':
+    parameters:
+      - name: orderId
+        in: path
+        description: ID of order
+        required: true
+        schema:
+          type: integer
+          format: int64
     get:
       tags:
         - store
@@ -375,14 +369,6 @@ paths:
         For valid response try integer IDs with value <= 5 or > 10. Other values
         will generated exceptions
       operationId: getOrderById
-      parameters:
-        - name: orderId
-          in: path
-          description: ID of order that needs to be fetched
-          required: true
-          schema:
-            type: integer
-            format: int64
       responses:
         '200':
           description: successful operation
@@ -406,14 +392,6 @@ paths:
         For valid response try integer IDs with value < 1000. Anything above
         1000 or nonintegers will generate API errors
       operationId: deleteOrder
-      parameters:
-        - name: orderId
-          in: path
-          description: ID of the order that needs to be deleted
-          required: true
-          schema:
-            type: integer
-            format: int64
       responses:
         '400':
           description: Invalid ID supplied
@@ -530,19 +508,19 @@ paths:
         default:
           description: successful operation
   '/user/{username}':
+    parameters:
+      - name: username
+        in: path
+        description: 'The user name. Use user1 for testing. '
+        required: true
+        schema:
+          type: string
     get:
       tags:
         - user
       summary: Get user by user name
       description: ''
       operationId: getUserByName
-      parameters:
-        - name: username
-          in: path
-          description: 'The name that needs to be fetched. Use user1 for testing. '
-          required: true
-          schema:
-            type: string
       responses:
         '200':
           description: successful operation
@@ -564,13 +542,6 @@ paths:
       x-swagger-router-controller: UserController
       description: This can only be done by the logged in user.
       operationId: updateUser
-      parameters:
-        - name: username
-          in: path
-          description: name that need to be deleted
-          required: true
-          schema:
-            type: string
       responses:
         default:
           description: successful operation
@@ -592,13 +563,6 @@ paths:
       summary: Delete user
       description: This can only be done by the logged in user.
       operationId: deleteUser
-      parameters:
-        - name: username
-          in: path
-          description: The name that needs to be deleted
-          required: true
-          schema:
-            type: string
       responses:
         '400':
           description: Invalid username supplied


### PR DESCRIPTION
It's typically preferable to document path parameters at the path level. This reduces duplication.  
Path parameters only need to be at the method level if two methods use the same segment differently for some reason (I can't think of a use case for this off the top of my head).