### PR TITLE
updatePetWithForm using patch

### DIFF
--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -221,7 +221,7 @@ paths:
         - petstore_auth:
             - 'write:pets'
             - 'read:pets'
-    post:
+    patch:
       tags:
         - pet
       summary: Updates a pet in the store with form data
@@ -235,16 +235,18 @@ paths:
           schema:
             type: integer
             format: int64
-        - name: name
-          in: query
-          description: Name of pet that needs to be updated
-          schema:
-            type: string
-        - name: status
-          in: query
-          description: Status of pet that needs to be updated
-          schema:
-            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Name of pet that needs to be updated
+                status:
+                  type: string
+                  description: Status of pet that needs to be updated
       responses:
         '405':
           description: Invalid input


### PR DESCRIPTION
Changed `updatePetWithForm` to use PATCH instead of PUT. Also moved the form from the query to the body.

POST is typically used to create resources, since it's not idempotent. PATCH is suitable since it describes a partial update to the resource rather than updating/replacing the resource completely.

Query parameters are typically used in GET requests that have no bodies. When updating a resource the body is more appropriate for the payload. The format is identical either way, only the location changes.