### PR TITLE
Replace category and tag objects with simple string

### DIFF
--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -676,19 +676,6 @@ components:
       xml:
         name: address
       type: object
-    Category:
-      x-swagger-router-model: io.swagger.petstore.model.Category
-      properties:
-        id:
-          type: integer
-          format: int64
-          example: 1
-        name:
-          type: string
-          example: Dogs
-      xml:
-        name: category
-      type: object
     User:
       x-swagger-router-model: io.swagger.petstore.model.User
       properties:
@@ -722,17 +709,6 @@ components:
       xml:
         name: user
       type: object
-    Tag:
-      x-swagger-router-model: io.swagger.petstore.model.Tag
-      properties:
-        id:
-          type: integer
-          format: int64
-        name:
-          type: string
-      xml:
-        name: tag
-      type: object
     Pet:
       x-swagger-router-model: io.swagger.petstore.model.Pet
       required:
@@ -747,7 +723,8 @@ components:
           type: string
           example: doggie
         category:
-          $ref: '#/components/schemas/Category'
+          type: string
+          example: Dogs
         photoUrls:
           type: array
           xml:
@@ -761,7 +738,7 @@ components:
           xml:
             wrapped: true
           items:
-            $ref: '#/components/schemas/Tag'
+            type: string
             xml:
               name: tag
         status:


### PR DESCRIPTION
The API doesn't document possible `id`s or `name`s for either, and doesn't provide endpoints to look them up so it's not clear how one producing or consuming an implementation would know what to do with them. 

Also it doesn't make sense to send both the id and name in a request.