### PR TITLE
Don't use GET for log in or out

### DIFF
--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -476,25 +476,27 @@ paths:
               items:
                 $ref: '#/components/schemas/User'
   /user/login:
-    get:
+    post:
       tags:
         - user
       summary: Logs user into the system
       description: ''
       operationId: loginUser
-      parameters:
-        - name: username
-          in: query
-          description: The user name for login
-          required: false
-          schema:
-            type: string
-        - name: password
-          in: query
-          description: The password for login in clear text
-          required: false
-          schema:
-            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                username:
+                  description: The user name for login
+                  type: string
+                password:
+                  description: The password for login in clear text
+                  type: string
+              required:
+                - username
+                - password
       responses:
         '200':
           description: successful operation
@@ -519,7 +521,7 @@ paths:
         '400':
           description: Invalid username/password supplied
   /user/logout:
-    get:
+    put:
       tags:
         - user
       summary: Logs out current logged in user session


### PR DESCRIPTION
GET should never be used for logging in or out of an API. 
* GET is cached
   * you can't be sure you'll actually get a new log in/out and not a cached response
  * user credentials could be cached in the browser history or intermediate servers (!)