### PR TITLE
Correct ordering of store/user tag metadata in openapi.yaml

### DIFF
--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -26,12 +26,12 @@ tags:
       description: Find out more
       url: 'http://swagger.io'
   - name: store
-    description: Operations about user
-  - name: user
     description: Access to Petstore orders
     externalDocs:
       description: Find out more about our store
       url: 'http://swagger.io'
+  - name: user
+    description: Operations about user
 paths:
   /pet:
     post:


### PR DESCRIPTION
This PR corrects the ordering of store/user tag metadata in openapi.yaml

It looks like the tags were re-ordered alphabetically in a refactor but the metadata was not copied

## Testing

Copied into local Swagger Editor using Docker

- [x] No errors shown on screen during parse
- [x] Order is corrected after re-render