### PR TITLE
Added a CI workflow to use GitHub actions to build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Java CI build and test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        java: [8, 11]
+      fail-fast: false
+      max-parallel: 4
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Verify with Maven
+        run: mvn verify
+...


### PR DESCRIPTION
Make use of a CI workflow using a GitHub actions to build and test on a push event. GitHub allows up to 4 concurrent runners. This test the project on Java 8, 11 LTS for Windows, Linux, and MacOS.