### PR TITLE
Display https instead of http url

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ Once started, you can navigate to http://localhost:8080/api/v3/openapi.json to v
 This tells you that the server is up and ready to demonstrate Swagger.
 
 ### Using the UI
-There is an HTML5-based API tool bundled in this sample--you can view it it at [http://localhost:8080](http://localhost:8080). This lets you inspect the API using an interactive UI.  You can access the source of this code from [here](https://github.com/swagger-api/swagger-ui)
+There is an HTML5-based API tool bundled in this sample--you can view it it at [http://localhost:8080](http://localhost:8080). This lets you inspect the API using an interactive UI.  You can access the source of this code from [here](https://github.com/swagger-api/swagger-ui).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We welcome suggestion both the code and the API design.
 To make changes to the design itself, take a look at https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml.
 
 This is a java project to build a stand-alone server which implements the OpenAPI 3 Spec.  You can find out
-more about both the spec and the framework at http://swagger.io.
+more about both the spec and the framework at https://swagger.io.
 
 This sample is based on [swagger-inflector](https://github.com/swagger-api/swagger-inflector), and provides an example of swagger / OpenAPI 3 petstore.
 


### PR DESCRIPTION
I don't see a reason to use `http` in the url to swagger.io, so I changed it to `https`.
Moreover, the last sentence was missing the full stop.