### PR TITLE
fix: quote strings to ensure valid JSON

### DIFF
--- a/src/main/java/io/swagger/petstore/controller/UserController.java
+++ b/src/main/java/io/swagger/petstore/controller/UserController.java
@@ -106,7 +106,7 @@ public class UserController {
                 .contentType(Util.getMediaType(request))
                 .header("X-Rate-Limit", String.valueOf(5000))
                 .header("X-Expires-After", date.toString())
-                .entity("Logged in user session: " + RandomUtils.nextLong());
+                .entity("\"Logged in user session: " + RandomUtils.nextLong() + "\"");
     }
 
     public ResponseContext logoutUser(final RequestContext request) {


### PR DESCRIPTION
The `loginUser` method has a response of type `"application/json": { "schema": { "type": "string" } }`. In order that the response is valid JSON, it needs to be quoted.