### PR TITLE
openapi.yaml: use api-key for header name

### DIFF
--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -259,7 +259,7 @@ paths:
       description: ''
       operationId: deletePet
       parameters:
-        - name: api_key
+        - name: api-key
           in: header
           description: ''
           required: false
@@ -815,5 +815,5 @@ components:
             'read:pets': read your pets
     api_key:
       type: apiKey
-      name: api_key
+      name: api-key
       in: header


### PR DESCRIPTION
Headers with _ are stripped by some web servers.

See also https://github.com/OAI/OpenAPI-Specification/issues/3225