### PR TITLE
Fix validation for generators that expect at least one success response

### DIFF
--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -246,6 +246,15 @@ paths:
           schema:
             type: string
       responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
         '405':
           description: Invalid input
       security:
@@ -273,6 +282,8 @@ paths:
             type: integer
             format: int64
       responses:
+        '200':
+          description: successful operation
         '400':
           description: Invalid pet value
       security:
@@ -415,6 +426,8 @@ paths:
             type: integer
             format: int64
       responses:
+        '200':
+          description: successful operation
         '400':
           description: Invalid ID supplied
         '404':
@@ -427,7 +440,7 @@ paths:
       description: This can only be done by the logged in user.
       operationId: createUser
       responses:
-        default:
+        '200':
           description: successful operation
           content:
             application/json:
@@ -527,7 +540,7 @@ paths:
       operationId: logoutUser
       parameters: []
       responses:
-        default:
+        '200':
           description: successful operation
   '/user/{username}':
     get:
@@ -572,8 +585,15 @@ paths:
           schema:
             type: string
       responses:
-        default:
+        '200':
           description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
       requestBody:
         description: Update an existent user in the store
         content:
@@ -600,6 +620,8 @@ paths:
           schema:
             type: string
       responses:
+        '200':
+          description: successful operation
         '400':
           description: Invalid username supplied
         '404':


### PR DESCRIPTION
This update adds at least one successful HTTP `Response Object` to each `Responses Object`.

According to OAS 3.0.3 Spec:

> The default MAY be used as a default response object for all HTTP codes that are not covered individually by the specification.
>
> The `Responses Object` MUST contain at least one response code, and it SHOULD be the response for a successful operation call.

[Specification link](https://swagger.io/specification/v3/#:~:text=and%20it%20SHOULD%20be%20the%20response%20for%20a%20successful%20operation)

Providing at least one response for a successful operation is only a recommendation (SHOULD), but not returning a success response for these operations doesn't make sense from a practical point of view.

According to the current document, the `paths./pet/{petId}.delete` operation, for example, can only return an error, even if the operation was successful. The example server, however, returns a 200.

Fixes swagger-api/swagger-petstore#112