### PR TITLE
fix(petstore): remove unused tags (store/user) in OpenAPI 3.1

### DIFF
--- a/src/main/java/io/swagger/petstore/resource/DefinitionResource.java
+++ b/src/main/java/io/swagger/petstore/resource/DefinitionResource.java
@@ -53,20 +53,7 @@ import io.swagger.v3.oas.annotations.tags.Tags;
                                 description = "Find out more",
                                 url = "https://swagger.io"
                         )
-                ),
-                @Tag(
-                        name = "store",
-                        description = "Access to Petstore orders",
-                        externalDocs = @ExternalDocumentation(
-                                description = "Find out more about our store",
-                                url = "https://swagger.io"
-                        )
-                ),
-                @Tag(
-                        name = "user",
-                        description = "Operations about user"
                 )
-
         }
 )
 @SecuritySchemes(

--- a/src/main/java/io/swagger/petstore/resource/PetResource.java
+++ b/src/main/java/io/swagger/petstore/resource/PetResource.java
@@ -29,7 +29,7 @@ public class PetResource {
     @GET
     @Path("/{petId}")
     @Operation(summary = "Find pet by it's identifier.",
-            tags = {"pets"},
+            tags = {"pet"},
             description = "Returns a pet when 0 < ID <= 10.  ID > 10 or non-integers will simulate API error conditions.",
             security = {
                     @SecurityRequirement(name = "petstore_auth", scopes = {"write:pets", "read:pets"}),
@@ -209,7 +209,7 @@ public class PetResource {
 /*  @GET
   @Path("/findByStatus")
   @Operation(summary = "Finds Pets by status",
-          tags = {"pets"},
+          tags = {"pet"},
     description = "Multiple status values can be provided with comma seperated strings",
           responses = {
                   @ApiResponse(
@@ -237,7 +237,7 @@ public class PetResource {
   @GET
   @Path("/findByTags")
   @Operation(summary = "Finds Pets by tags",
-          tags = {"pets"},
+          tags = {"pet"},
     description = "Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.",
     responses = {
             @ApiResponse(description = "Pets matching criteria",

--- a/src/main/webapp/code-first/openapi.json
+++ b/src/main/webapp/code-first/openapi.json
@@ -29,16 +29,6 @@
       "description" : "Find out more",
       "url" : "https://swagger.io"
     }
-  }, {
-    "name" : "store",
-    "description" : "Access to Petstore orders",
-    "externalDocs" : {
-      "description" : "Find out more about our store",
-      "url" : "https://swagger.io"
-    }
-  }, {
-    "name" : "user",
-    "description" : "Operations about user"
   } ],
   "paths" : {
     "/pet" : {

--- a/src/main/webapp/code-first/openapi.yaml
+++ b/src/main/webapp/code-first/openapi.yaml
@@ -25,13 +25,6 @@ tags:
   externalDocs:
     description: Find out more
     url: https://swagger.io
-- name: store
-  description: Access to Petstore orders
-  externalDocs:
-    description: Find out more about our store
-    url: https://swagger.io
-- name: user
-  description: Operations about user
 paths:
   /pet:
     put:


### PR DESCRIPTION
This change removes the unused tags from OpenAPI 3.1 Petstore definition generated from the source code.