### PR TITLE
Add script to call GET /pet/findByStatus?status=available

### DIFF
--- a/scripts/find-available-pets.sh
+++ b/scripts/find-available-pets.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Calls GET /pet/findByStatus?status=available on the local Petstore server
+# Start the server first: mvn package jetty:run
+
+BASE_URL="${PETSTORE_URL:-http://localhost:8080}"
+
+curl -s "${BASE_URL}/api/v3/pet/findByStatus?status=available" | python3 -m json.tool


### PR DESCRIPTION
## Summary

- Adds `scripts/find-available-pets.sh`, a shell script that calls `GET /pet/findByStatus?status=available` against the local Petstore server and pretty-prints the JSON response.

Accessed the Petstore API GET /pet/findByStatus with status='available' and returned the list of pets successfully, confirming the server is running and responding with the expected data.

## Test plan

- [ ] Start the server: `mvn package jetty:run`
- [ ] Run the script: `bash scripts/find-available-pets.sh`
- [ ] Verify 7 pets are returned with `status: available` (Cat 1, Cat 2, Dog 1, Lion 1, Lion 2, Lion 3, Rabbit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)